### PR TITLE
Adds Shared<T> a wrapper for sharing data between handlers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ impl<T> Shared<T> {
 
     /// Loads new contents into a shared value, if the value already contained
     /// data the old value is returned
-    pub fn load(&self, cs: &CriticalSection, value: T) -> Option<T> {
+    pub fn put(&self, cs: &CriticalSection, value: T) -> Option<T> {
         self.inner.borrow(cs).replace(Some(value))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,7 @@
 )]
 #![no_std]
 
-use core::{
-    cell::{RefCell, UnsafeCell},
-    ops::{Deref, DerefMut},
-};
+use core::cell::{RefCell, UnsafeCell};
 
 /// A peripheral
 #[derive(Debug)]
@@ -164,10 +161,8 @@ impl<T> Shared<T> {
             .borrow(cs)
             .try_borrow()
             .ok()
-            .and_then(|inner| match inner.deref() {
-                Some(_) => Some(core::cell::Ref::map(inner, |v| v.as_ref().unwrap())),
-                None => None,
-            })
+            .filter(|inner| inner.is_some())
+            .map(|inner| core::cell::Ref::map(inner, |v| v.as_ref().unwrap()))
     }
 
     /// Attempts to get a reference to the data in the shared value, may fail
@@ -178,9 +173,7 @@ impl<T> Shared<T> {
             .borrow(cs)
             .try_borrow_mut()
             .ok()
-            .and_then(|mut inner| match inner.deref_mut() {
-                Some(_) => Some(core::cell::RefMut::map(inner, |v| v.as_mut().unwrap())),
-                None => None,
-            })
+            .filter(|inner| inner.is_some())
+            .map(|inner| core::cell::RefMut::map(inner, |v| v.as_mut().unwrap()))
     }
 }


### PR DESCRIPTION
This adds `Shared<T>` which is a helper for sharing values between the main thread and interrupt handlers. It is essentially a wrapper around `Mutex<RefCell<Option<T>>>` that adds some helper methods to make the standard ways of executing this common pattern less painful.

e.g. in one of the examples from the stm32f0xx-hal it makes the following simplifications:
### Declaration
```rust
static SHARED: Mutex<RefCell<Option<Shared>>> = Mutex::new(RefCell::new(None));
```
to
```rust
static SHARED: Shared<MyShared> = Shared::new();
```
### Loading
```rust
*SHARED.borrow(cs).borrow_mut() = Some(Shared { adc, tx });
```
to
```rust
SHARED.put(cs, MyShared { adc, tx });
```
### Referencing
```rust
if let Some(ref mut shared) = SHARED.borrow(cs).borrow_mut().deref_mut() {
```
to
```rust
if let Some(mut shared) = SHARED.get_mut(cs) {
    let shared = shared.deref_mut();
    /* interrupt handler */
```

There are still some deficiencies that I would like to solve at a future date, but I think it is suitable to be put into use as it is. I'd rather that `get` and `get_mut` could return `Option<&T>` and `Option<&mut T>` values respectively, but I don't think that can be done without replacing the use of `RefCell` internally. All attempts I've made have run afoul of lifetimes not living long enough to sustain the references passed externally.