### PR TITLE
Add `#[inline(always)]` to CriticalSection::new().

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ impl CriticalSection {
     ///
     /// This method is meant to be used to create safe abstractions rather than
     /// meant to be directly used in applications.
+    #[inline(always)]
     pub unsafe fn new() -> Self {
         CriticalSection { _0: () }
     }


### PR DESCRIPTION
This is the only non-generic function in this crate. Rustc doesn't
inline non-generic functions across crate boundaries, so without
`#[inline]`, this trivial function would still end up taking space and
cpu time in crates that use this, even though it does literally nothing
at runtime.