### PR TITLE
Remove const-fn feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,3 @@ license = "MIT OR Apache-2.0"
 name = "bare-metal"
 repository = "https://github.com/rust-embedded/bare-metal"
 version = "0.2.5"
-
-[build-dependencies]
-rustc_version = "0.2.3"
-
-[features]
-const-fn = [] # Unused, but kept for backwards compatibility

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,0 @@
-extern crate rustc_version;
-
-fn main() {
-    let vers = rustc_version::version().unwrap();
-
-    if vers.major == 1 && vers.minor < 31 {
-        println!("cargo:rustc-cfg=unstable_const_fn")
-    }
-}


### PR DESCRIPTION
Per #22, as of Rust v1.31 const-fn was stablized.
Removing the feature in preparation of a 1.0 release.

Related to #11