### PR TITLE
Add fences to mutex methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 use core::cell::UnsafeCell;
 use core::marker::PhantomData;
+use core::sync::atomic::{fence, Ordering};
 
 /// Critical section token.
 ///
@@ -61,6 +62,7 @@ impl<T> Mutex<T> {
     /// This does not require locking or a critical section since it takes `&mut self`, which
     /// guarantees unique ownership already.
     pub fn get_mut(&mut self) -> &mut T {
+        fence(Ordering::SeqCst);
         unsafe { &mut *self.inner.get() }
     }
 
@@ -71,6 +73,7 @@ impl<T> Mutex<T> {
 
     /// Borrows the data for the duration of the critical section.
     pub fn borrow<'cs>(&'cs self, _cs: CriticalSection<'cs>) -> &'cs T {
+        fence(Ordering::SeqCst);
         unsafe { &*self.inner.get() }
     }
 }


### PR DESCRIPTION
Without the fences the Mutex doesn't behave as expected.

Given this example:
```rust
static FOO: Mutex<RefCell<bool>> = Mutex::new(RefCell::new(false));

pub fn main() {
    let mut count = 0;
    loop {
        let cs = unsafe { CriticalSection::new() };
        if *FOO.borrow(cs).borrow() {
            break
        }
        count += 1;
    }
    let mut black_box = 0;
    unsafe { ptr::write_volatile(&mut black_box as *mut _, count); }
}

#[no_mangle]
pub extern "Rust" fn bar() {
    let cs = unsafe { CriticalSection::new() };
    *FOO.borrow(cs).borrow_mut() = true;
}
```

It's expected that the value of `FOO` will be evaluated at each loop pass, right now that doesn't happen, `FOO` is only evaluated once and if the value is false then the function branchs to an infinite loop:
```
.LBB1_2:
        b       .LBB1_2
```

[godbolt link](https://rust.godbolt.org/z/FYy8LT) (Remove the comment to add the fence and see the difference)

I decided to go for a `fence` instead of a `compiler_fence` to cover the cases where the processors have a cache or are out of order. We could change `SeqCst` for a pair of `Acquire` and `Release`, but then I think we would have to put one of them in the `Drop` implementation of the `CriticalSection`, but we can't really rely that drop will run (`mem::forget`), so I went with `SeqCst`, maybe I'm missing some other way...

It seems that we would need to yank previous versions, unfortunately.
