### PR TITLE
Document suitable conditions for the safety of CriticalSection and Mutex use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,9 @@ impl<'cs> CriticalSection<'cs> {
     ///
     /// This must only be called when the current core is in a critical section. The caller must
     /// ensure that the returned instance will not live beyond the end of the critical section.
-    /// Moreover, the caller must use the adequate fences to prevent the compiler from moving the
-    /// instructions inside the critical section to the outside of it.
+    /// Moreover, the caller must use adequate fences to prevent the compiler from moving the
+    /// instructions inside the critical section to the outside of it. Sequentially consistent fences are
+    /// suggested immediately after entry and immediately before exit from the critical section.
     ///
     /// Note that the lifetime `'cs` of the returned instance is unconstrained. User code must not
     /// be able to influence the lifetime picked for this type, since that might cause it to be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ impl<'cs> CriticalSection<'cs> {
     ///
     /// This must only be called when the current core is in a critical section. The caller must
     /// ensure that the returned instance will not live beyond the end of the critical section.
+    /// Moreover, the caller must use the adequate fences to prevent the compiler from moving the
+    /// instructions inside the critical section to the outside of it.
     ///
     /// Note that the lifetime `'cs` of the returned instance is unconstrained. User code must not
     /// be able to influence the lifetime picked for this type, since that might cause it to be
@@ -59,7 +61,9 @@ impl<T> Mutex<T> {
     /// Gets a mutable reference to the contained value when the mutex is already uniquely borrowed.
     ///
     /// This does not require locking or a critical section since it takes `&mut self`, which
-    /// guarantees unique ownership already.
+    /// guarantees unique ownership already. Care must be taken when using this method to
+    /// **unsafely** access `static mut` variables, appropriate fences must be used to prevent
+    /// unwanted optimizations.
     pub fn get_mut(&mut self) -> &mut T {
         unsafe { &mut *self.inner.get() }
     }


### PR DESCRIPTION
For more information, see https://github.com/rust-embedded/bare-metal/pull/33 and more specifically, https://github.com/rust-embedded/bare-metal/pull/33#issuecomment-634210146.

I'm a bit on the fence (heh) with respect to the documentation of `get_mut`, I would like some feedback on that.