### PR TITLE
Prepare v0.2.6, semver-trick release depending on 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.2.6] - 2020-07-01
+
+This release in the 0.2 series exists for compatibility with 1.0.0;
+there are no functional changes compared to v0.2.5.
+
 ## [v0.2.5] - 2019-08-29
 
 ### Changed
@@ -66,7 +71,8 @@ YANKED due to a soundness issue: see v0.2.1 for details
 
 - Initial release
 
-[Unreleased]: https://github.com/japaric/bare-metal/compare/v0.2.5...HEAD
+[Unreleased]: https://github.com/japaric/bare-metal/compare/v0.2.6...HEAD
+[v0.2.6]: https://github.com/japaric/bare-metal/compare/v0.2.5...v0.2.6
 [v0.2.5]: https://github.com/japaric/bare-metal/compare/v0.2.4...v0.2.5
 [v0.2.4]: https://github.com/japaric/bare-metal/compare/v0.2.3...v0.2.4
 [v0.2.3]: https://github.com/japaric/bare-metal/compare/v0.2.2...v0.2.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,10 @@ keywords = ["bare-metal", "register", "peripheral", "interrupt"]
 license = "MIT OR Apache-2.0"
 name = "bare-metal"
 repository = "https://github.com/japaric/bare-metal"
-version = "0.2.5"
+version = "0.2.6"
+
+[dependencies]
+bare-metal = "1.0.0"
 
 [build-dependencies]
 rustc_version = "0.2.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@
 #![deny(warnings)]
 #![no_std]
 
-use core::cell::UnsafeCell;
+extern crate bare_metal;
+pub use bare_metal::{CriticalSection, Mutex};
 
 /// A peripheral
 #[derive(Debug)]
@@ -36,66 +37,8 @@ impl<T> Peripheral<T> {
     }
 }
 
-/// Critical section token
-///
-/// Indicates that you are executing code within a critical section
-pub struct CriticalSection {
-    _0: (),
-}
-
-impl CriticalSection {
-    /// Creates a critical section token
-    ///
-    /// This method is meant to be used to create safe abstractions rather than
-    /// meant to be directly used in applications.
-    pub unsafe fn new() -> Self {
-        CriticalSection { _0: () }
-    }
-}
-
-/// A "mutex" based on critical sections
-///
-/// # Safety
-///
-/// **This Mutex is only safe on single-core systems.**
-///
-/// On multi-core systems, a `CriticalSection` **is not sufficient** to ensure exclusive access.
-pub struct Mutex<T> {
-    inner: UnsafeCell<T>,
-}
-
-impl<T> Mutex<T> {
-    /// Creates a new mutex
-    pub const fn new(value: T) -> Self {
-        Mutex {
-            inner: UnsafeCell::new(value),
-        }
-    }
-}
-
-impl<T> Mutex<T> {
-    /// Borrows the data for the duration of the critical section
-    pub fn borrow<'cs>(&'cs self, _cs: &'cs CriticalSection) -> &'cs T {
-        unsafe { &*self.inner.get() }
-    }
-}
-
-/// ``` compile_fail
-/// fn bad(cs: &bare_metal::CriticalSection) -> &u32 {
-///     let x = bare_metal::Mutex::new(42u32);
-///     x.borrow(cs)
-/// }
-/// ```
-#[allow(dead_code)]
-const GH_6: () = ();
-
 /// Interrupt number
 pub unsafe trait Nr {
     /// Returns the number associated with an interrupt
     fn nr(&self) -> u8;
 }
-
-// NOTE A `Mutex` can be used as a channel so the protected data must be `Send`
-// to prevent sending non-Sendable stuff (e.g. access tokens) across different
-// execution contexts (e.g. interrupts)
-unsafe impl<T> Sync for Mutex<T> where T: Send {}


### PR DESCRIPTION
Note this PR is against a v0.2 branch which currently reflects the v0.2.5 release.

This is a semver trick release so that applications can depend on both v0.2 and v1.0 of bare-metal at the same time without type conflicts.

I think I've done this right...