### PR TITLE
Add inherent `impl` block for `Mutex<RefCell<T>>`

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,7 +5,7 @@ status = [
     "ci (stable, ubuntu-latest)",
     "ci (stable, macOS-latest)",
     "ci (stable, windows-latest)",
-    "ci (1.31.0, ubuntu-latest)",
+    "ci (1.50.0, ubuntu-latest)",
     "rustfmt",
     "clippy",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
         include:
           # Test MSRV
-          - rust: 1.31.0
+          - rust: 1.50.0
             os: ubuntu-latest
 
           # Test nightly but don't fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Added inherent `impl` block for `Mutex<RefCell<T>>` to help reduce verbosity
+- Increased MSRV to 1.50.0
+
 ## [v1.0.0] - 2020-06-23
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MSP430, and RISCV teams][teams].
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.31.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.50.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,11 @@ impl<T> Mutex<RefCell<T>> {
     /// Borrow the data and call [`RefCell::replace`]
     ///
     /// This is equivalent to `self.borrow(cs).replace(t)`
+    ///
+    /// # Panics
+    ///
+    /// This call could panic. See the documentation for [`RefCell::replace`]
+    /// for more details.
     #[inline]
     #[track_caller]
     pub fn replace<'cs>(&'cs self, cs: CriticalSection<'cs>, t: T) -> T {
@@ -145,6 +150,11 @@ impl<T> Mutex<RefCell<T>> {
     /// Borrow the data and call [`RefCell::replace_with`]
     ///
     /// This is equivalent to `self.borrow(cs).replace_with(f)`
+    ///
+    /// # Panics
+    ///
+    /// This call could panic. See the documentation for
+    /// [`RefCell::replace_with`] for more details.
     #[inline]
     #[track_caller]
     pub fn replace_with<'cs, F>(&'cs self, cs: CriticalSection<'cs>, f: F) -> T
@@ -157,6 +167,11 @@ impl<T> Mutex<RefCell<T>> {
     /// Borrow the data and call [`RefCell::borrow`]
     ///
     /// This is equivalent to `self.borrow(cs).borrow()`
+    ///
+    /// # Panics
+    ///
+    /// This call could panic. See the documentation for [`RefCell::borrow`]
+    /// for more details.
     #[inline]
     #[track_caller]
     pub fn borrow_ref<'cs>(&'cs self, cs: CriticalSection<'cs>) -> Ref<'cs, T> {
@@ -166,6 +181,11 @@ impl<T> Mutex<RefCell<T>> {
     /// Borrow the data and call [`RefCell::borrow_mut`]
     ///
     /// This is equivalent to `self.borrow(cs).borrow_mut()`
+    ///
+    /// # Panics
+    ///
+    /// This call could panic. See the documentation for [`RefCell::borrow_mut`]
+    /// for more details.
     #[inline]
     #[track_caller]
     pub fn borrow_ref_mut<'cs>(&'cs self, cs: CriticalSection<'cs>) -> RefMut<'cs, T> {
@@ -177,6 +197,11 @@ impl<T: Default> Mutex<RefCell<T>> {
     /// Borrow the data and call [`RefCell::take`]
     ///
     /// This is equivalent to `self.borrow(cs).take()`
+    ///
+    /// # Panics
+    ///
+    /// This call could panic. See the documentation for [`RefCell::take`]
+    /// for more details.
     #[inline]
     #[track_caller]
     pub fn take<'cs>(&'cs self, cs: CriticalSection<'cs>) -> T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ impl<T> Mutex<RefCell<T>> {
     ///
     /// This is equivalent to `self.borrow(cs).replace(t)`
     #[inline]
+    #[track_caller]
     pub fn replace<'cs>(&'cs self, cs: CriticalSection<'cs>, t: T) -> T {
         self.borrow(cs).replace(t)
     }
@@ -145,6 +146,7 @@ impl<T> Mutex<RefCell<T>> {
     ///
     /// This is equivalent to `self.borrow(cs).replace_with(f)`
     #[inline]
+    #[track_caller]
     pub fn replace_with<'cs, F>(&'cs self, cs: CriticalSection<'cs>, f: F) -> T
     where
         F: FnOnce(&mut T) -> T,
@@ -156,6 +158,7 @@ impl<T> Mutex<RefCell<T>> {
     ///
     /// This is equivalent to `self.borrow(cs).borrow()`
     #[inline]
+    #[track_caller]
     pub fn borrow_ref<'cs>(&'cs self, cs: CriticalSection<'cs>) -> Ref<'cs, T> {
         self.borrow(cs).borrow()
     }
@@ -164,6 +167,7 @@ impl<T> Mutex<RefCell<T>> {
     ///
     /// This is equivalent to `self.borrow(cs).borrow_mut()`
     #[inline]
+    #[track_caller]
     pub fn borrow_ref_mut<'cs>(&'cs self, cs: CriticalSection<'cs>) -> RefMut<'cs, T> {
         self.borrow(cs).borrow_mut()
     }
@@ -174,6 +178,7 @@ impl<T: Default> Mutex<RefCell<T>> {
     ///
     /// This is equivalent to `self.borrow(cs).take()`
     #[inline]
+    #[track_caller]
     pub fn take<'cs>(&'cs self, cs: CriticalSection<'cs>) -> T {
         self.borrow(cs).take()
     }


### PR DESCRIPTION
Add inherent functions to `Mutex<RefCell<T>>` to reduce verbosity when
using the type. Add a note to the `Mutex` documentation explaining why
`Mutex::borrow` does not return `&mut T` and point out the newly created
methods on `Mutex<RefCell<T>>`. The design of `Mutex::borrow` is a
frequently asked question, so it helps to explicitly document the
decisions.

Closes #43.