### PR TITLE
Explain test case, rename anchor const for readability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,11 @@ impl<T> Mutex<T> {
 // execution contexts (e.g. interrupts)
 unsafe impl<T> Sync for Mutex<T> where T: Send {}
 
+/// In this test, the compiler will implicitly assign the produced reference's lifetime to cs
+/// (consequently, it is checked that the caller provides a sufficiently long-lived cs). However,
+/// the mutex itself is short-lived, and this tests that the &self does actually live as long as
+/// the critical section (which here it does not, causing compilation failure):
+///
 /// ``` compile_fail
 /// fn bad(cs: bare_metal::CriticalSection) -> &u32 {
 ///     let x = bare_metal::Mutex::new(42u32);
@@ -94,4 +99,4 @@ unsafe impl<T> Sync for Mutex<T> where T: Send {}
 /// ```
 #[allow(dead_code)]
 #[doc(hidden)]
-const GH_6: () = ();
+const DOCTEST_ANCHOR: () = ();


### PR DESCRIPTION
The rename is primarily because I didn't get what the constant on the first read (and it really gets to you when you review code and find something that's obviously there for a purpose but it's also obviously not actually doing anything).

The comment is added to help readers who are led astray by the earlier warnings to not let the user pick the produced lifetime of a CS (here it's really controlled by the consumer) and miss that the mutex itself is shortlived.